### PR TITLE
Readded mock testing driver

### DIFF
--- a/drivers/storage/mock/executor/mock_executor.go
+++ b/drivers/storage/mock/executor/mock_executor.go
@@ -1,5 +1,3 @@
-// +build mock
-
 package executor
 
 import (
@@ -83,10 +81,11 @@ func (d *Executor) LocalDevices(
 
 // GetInstanceID gets the mock instance ID.
 func GetInstanceID() *types.InstanceID {
-	return &types.InstanceID{
-		ID:       "12345",
-		Metadata: instanceIDMetadata(),
+	iid := &types.InstanceID{
+		ID: "12345",
 	}
+	_ = iid.MarshalMetadata(instanceIDMetadata())
+	return iid
 }
 
 func instanceIDMetadata() json.RawMessage {

--- a/drivers/storage/mock/storage/mock_storage.go
+++ b/drivers/storage/mock/storage/mock_storage.go
@@ -1,5 +1,3 @@
-// +build mock
-
 package mock
 
 import (
@@ -103,8 +101,11 @@ func (d *driver) NextDeviceInfo(
 func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
-	iid, _ := d.InstanceID(ctx, opts)
-	return &types.Instance{Name: "mockInstance", InstanceID: iid}, nil
+	iid := context.MustInstanceID(ctx)
+	if iid.ID != "" {
+		return &types.Instance{Name: "mockInstance", InstanceID: iid}, nil
+	}
+	return nil, goof.New("missing instanceID in mock")
 }
 
 func (d *driver) Volumes(

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -5,6 +5,7 @@ import (
 	//_ "github.com/emccode/libstorage/drivers/storage/ec2/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/gce/executor"
 	_ "github.com/emccode/libstorage/drivers/storage/isilon/executor"
+	_ "github.com/emccode/libstorage/drivers/storage/mock/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/openstack/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/rackspace/executor"
 	_ "github.com/emccode/libstorage/drivers/storage/scaleio/executor"

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -3,6 +3,7 @@ package remote
 import (
 	// import to load
 	_ "github.com/emccode/libstorage/drivers/storage/isilon/storage"
+	_ "github.com/emccode/libstorage/drivers/storage/mock/storage"
 	_ "github.com/emccode/libstorage/drivers/storage/scaleio/storage"
 	_ "github.com/emccode/libstorage/drivers/storage/vbox/storage"
 	_ "github.com/emccode/libstorage/drivers/storage/vfs/storage"


### PR DESCRIPTION
This commit reintroduces the mock testing driver into the build.
There were small updates to latest interfaceID functionality.
The mock driver makes developing against libstorage easy for
testing as it represent a completely stateless and populated
state with multiple volumes.
