### PR TITLE
Fix issue with attaching volumes when mounting to separate hosts

### DIFF
--- a/drivers/integration/docker/docker.go
+++ b/drivers/integration/docker/docker.go
@@ -185,8 +185,14 @@ func (d *driver) Mount(
 		return "", nil, goof.New("no volume returned or created")
 	}
 
+	ma, err := d.localAttachmentOfVolume(ctx, vol)
+	if err != nil {
+		return "", nil, goof.New("problem getting local attachment of volume")
+	}
+
 	client := context.MustClient(ctx)
-	if len(vol.Attachments) == 0 || opts.Preempt {
+
+	if ma == nil || opts.Preempt {
 		mp, err := d.getVolumeMountPath(vol.Name)
 		if err != nil {
 			return "", nil, err
@@ -230,24 +236,13 @@ func (d *driver) Mount(
 
 	}
 
-	if len(vol.Attachments) == 0 {
-		return "", nil, goof.New("volume did not attach")
-	}
-
-	inst, err := client.Storage().InstanceInspect(ctx, utils.NewStore())
+	ma, err = d.localAttachmentOfVolume(ctx, vol)
 	if err != nil {
-		return "", nil, goof.New("problem getting instance ID")
-	}
-	var ma *types.VolumeAttachment
-	for _, att := range vol.Attachments {
-		if att.InstanceID.ID == inst.InstanceID.ID {
-			ma = att
-			break
-		}
+		return "", nil, goof.New("problem getting local attachment of volume")
 	}
 
 	if ma == nil {
-		return "", nil, goof.New("no local attachment found")
+		return "", nil, goof.New("volume did not attach")
 	}
 
 	if ma.DeviceName == "" {
@@ -331,27 +326,20 @@ func (d *driver) Unmount(
 		return nil
 	}
 
-	client := context.MustClient(ctx)
-
-	inst, err := client.Storage().InstanceInspect(ctx, utils.NewStore())
+	ma, err := d.localAttachmentOfVolume(ctx, vol)
 	if err != nil {
-		return goof.New("problem getting instance ID")
-	}
-	var ma *types.VolumeAttachment
-	for _, att := range vol.Attachments {
-		if att.InstanceID.ID == inst.InstanceID.ID {
-			ma = att
-			break
-		}
+		return goof.New("problem getting local attachment of volume")
 	}
 
 	if ma == nil {
-		return goof.New("no attachment found for instance")
+		return goof.New("no local attachment found for instance")
 	}
 
 	if ma.DeviceName == "" {
 		return goof.New("no device name found for attachment")
 	}
+
+	client := context.MustClient(ctx)
 
 	mounts, err := client.OS().Mounts(
 		ctx, ma.DeviceName, "", opts)
@@ -545,6 +533,23 @@ func (d *driver) NetworkName(
 	volumeName string,
 	opts types.Store) (string, error) {
 	return "", nil
+}
+
+func (d *driver) localAttachmentOfVolume(
+	ctx types.Context,
+	vol *types.Volume) (*types.VolumeAttachment, error) {
+	client := context.MustClient(ctx)
+	inst, err := client.Storage().InstanceInspect(ctx, utils.NewStore())
+	if err != nil {
+		return nil, goof.New("problem getting instance ID")
+	}
+
+	for _, att := range vol.Attachments {
+		if att.InstanceID.ID == inst.InstanceID.ID {
+			return att, nil
+		}
+	}
+	return nil, nil
 }
 
 func (d *driver) volumeRootPath() string {


### PR DESCRIPTION
When mounting a volume to separate hosts only the first host will actually get the mount. This is due to the logic we had in the mount function of the docker integration plugin. In order to mount we have to ensure the volume is attached. We do this by checking to see if the attachments is 0 and if it is we attach then mount, if not we just mount. This is correct when a volume can only be mounted to 1 host but when multiple hosts get involved, as in a NFS volume case,  mount will no longer mount since the volume is not attached. This PR fixes this issue by determining if the volume is attached to the host rather than looking plainly at the number of attachments.
