### PR TITLE
OpenStack Storage Driver

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -1208,3 +1208,55 @@ libstorage:
 - Snapshot and create volume from volume functionality is not available yet
   with this driver.
 - The driver supports VirtualBox 5.0.10+
+
+## OpenStack
+The OpenStack driver registers a storage driver named `openstack` with the
+`libStorage` driver manager and is used to connect and manage storage on OpenStack
+instances.
+
+### Configuration
+The following is an example configuration of the OpenStack driver.
+
+```yaml
+openstack:
+    authURL:              https://domain.com/openstack
+    userID:               0
+    userName:             myusername
+    password:             mypassword
+    tenantID:             0
+    tenantName:           customer
+    domainID:             0
+    domainName:           corp
+    regionName:           USNW
+    availabilityZoneName: Gold
+```
+
+#### Configuration Notes
+- `regionName` is optional, it should be empty if you only have one region.
+- `availabilityZoneName` is optional, the volume will be created in the default
+availability zone if not specified.
+
+For information on the equivalent environment variable and CLI flag names
+please see the section on how non top-level configuration properties are
+[transformed](./config.md#configuration-properties).
+
+### Activating the Driver
+To activate the OpenStack driver please follow the instructions for
+[activating storage drivers](./config.md#storage-drivers),
+using `openstack` as the driver name.
+
+### Examples
+Below is a full `config.yml` file that works with OpenStack.
+
+```yaml
+libstorage:
+  server:
+    services:
+      openstack:
+        driver: openstack
+        openstack:
+          authUrl: https://keystoneHost:35357/v2.0/
+          username: username
+          password: password
+          tenantName: tenantName
+```

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,8 @@ BUILD_TAGS :=   gofig \
 ifneq (true,$(TRAVIS))
 BUILD_TAGS +=   libstorage_storage_driver \
 				libstorage_storage_driver_vfs \
-				libstorage_storage_driver_openstack \
 				libstorage_storage_executor \
-				libstorage_storage_executor_vfs \
-				libstorage_storage_executor_openstack
+				libstorage_storage_executor_vfs
 endif
 endif
 
@@ -1144,6 +1142,13 @@ test-rbd-clean:
 
 test-vfs:
 	DRIVERS=vfs $(MAKE) ./drivers/storage/vfs/tests/vfs.test
+
+test-openstack:
+	DRIVERS=openstack $(MAKE) deps
+	DRIVERS=openstack $(MAKE) ./drivers/storage/openstack/tests/openstack.test
+
+test-openstack-clean:
+	DRIVERS=openstack $(MAKE) clean
 
 clean: $(GO_CLEAN)
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ BUILD_TAGS :=   gofig \
 ifneq (true,$(TRAVIS))
 BUILD_TAGS +=   libstorage_storage_driver \
 				libstorage_storage_driver_vfs \
+				libstorage_storage_driver_openstack \
 				libstorage_storage_executor \
-				libstorage_storage_executor_vfs
+				libstorage_storage_executor_vfs \
+				libstorage_storage_executor_openstack
 endif
 endif
 

--- a/api/types/types_drivers_os.go
+++ b/api/types/types_drivers_os.go
@@ -7,6 +7,7 @@ type NewOSDriver func() OSDriver
 type DeviceMountOpts struct {
 	MountOptions string
 	MountLabel   string
+	FsType       string
 	Opts         Store
 }
 

--- a/drivers/os/linux/linux.go
+++ b/drivers/os/linux/linux.go
@@ -136,9 +136,13 @@ func (d *driver) Mount(
 		return nil
 	}
 
-	fsType, err := probeFsType(deviceName)
-	if err != nil {
-		return err
+	fsType := opts.FsType
+	if opts.FsType == "" {
+		var err error
+		fsType, err = probeFsType(deviceName)
+		if err != nil {
+			return err
+		}
 	}
 
 	options := formatMountLabel("", opts.MountLabel)

--- a/drivers/storage/openstack/executor/openstack_executor.go
+++ b/drivers/storage/openstack/executor/openstack_executor.go
@@ -8,19 +8,26 @@ import (
 
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/openstack"
+	// the next import initializes and registers the OS drivers
+	_ "github.com/codedellemc/libstorage/imports/local"
 
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
+	"time"
 )
 
 type driver struct {
-	config gofig.Config
+	config   gofig.Config
+	osDriver types.OSDriver
 }
 
 func init() {
@@ -33,6 +40,15 @@ func newDriver() types.StorageExecutor {
 
 func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	d.config = config
+
+	var err error
+	if d.osDriver, err = registry.NewOSDriver(runtime.GOOS); err != nil {
+		return err
+	}
+	if err = d.osDriver.Init(ctx, config); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -40,24 +56,18 @@ func (d *driver) Name() string {
 	return openstack.Name
 }
 
-// InstanceID returns the local instance ID for the test
-func InstanceID(config gofig.Config) (*types.InstanceID, error) {
-	d := newDriver()
-	d.Init(nil, config)
-	return d.InstanceID(nil, nil)
-}
-
-func (d *driver) InstanceID(
-	ctx types.Context,
-	opts types.Store) (*types.InstanceID, error) {
-
-	uuid, metadataServerErr := getInstanceIDFromMetadataServer()
-	if metadataServerErr != nil {
-		uuid, cloudInitFileErr = getInstanceIDFromCloudInitFile()
-		if cloudInitFileErr != nil {
-			uuid, dmidecodeErr = getInstanceIDWithDMIDecode()
-			if dmidecodeErr != nil {
-				return nil, fmt.Errorf("%v ; %v ; %v", cloudInitFileErr, metadataServerErr, dmidecodeErr)
+func (d *driver) InstanceID(ctx types.Context, opts types.Store) (*types.InstanceID, error) {
+	fields := map[string]interface{}{}
+	uuid, err := getInstanceIDFromConfigDrive(ctx, d)
+	if err != nil {
+		fields["configDrive"] = err
+		uuid, err = getInstanceIDFromMetadataServer()
+		if err != nil {
+			fields["metadataServer"] = err
+			uuid, err = getInstanceIDWithDMIDecode()
+			if err != nil {
+				fields["dmidecode"] = err
+				return nil, goof.WithFields(fields, "unable to get InstanceID from any sources")
 			}
 		}
 	}
@@ -67,33 +77,9 @@ func (d *driver) InstanceID(
 	return iid, nil
 }
 
-func getInstanceIDFromCloudInitFile() (string, error) {
-	const instanceIDFile = "/var/lib/cloud/data/instance-id"
-	idBytes, err := ioutil.ReadFile(instanceIDFile)
-	if err != nil {
-		return "", goof.WithFieldE("file", instanceIDFile, "error reading file", err)
-	}
-
-	instanceID := string(idBytes)
-	instanceID = strings.TrimSpace(instanceID)
-
-	return instanceID, nil
-}
-
-func getInstanceIDFromMetadataServer() (string, error) {
-	const metadataURL = "http://169.254.169.254/openstack/latest/meta_data.json"
-	resp, err := http.Get(metadataURL)
-	if err != nil {
-		return "", goof.WithError("error getting metadata from "+metadataURL, err)
-	}
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", goof.WithError("io error reading metadata", err)
-	}
+func parseUUID(metadata []byte) (string, error) {
 	var decodedJSON interface{}
-	err = json.Unmarshal(data, &decodedJSON)
+	err := json.Unmarshal(metadata, &decodedJSON)
 	if err != nil {
 		return "", goof.WithError("error unmarshalling metadata", err)
 	}
@@ -109,21 +95,97 @@ func getInstanceIDFromMetadataServer() (string, error) {
 	return uuid, nil
 }
 
-func getInstanceIDWithDMIDecode() (string, error) {
-	cmd := exec.Command("dmidecode", "-t", "system")
-	cmdOut, err := cmd.Output()
-
+func execCommand(cmd string, args ...string) (string, error) {
+	command := exec.Command(cmd, args...)
+	out, err := command.Output()
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		stderr := string(exiterr.Stderr)
-		ctx.WithError(
-			exiterr,
-		).WithField(
-			"stderr", stderr,
-		).Error("error calling dmidecode")
-		return nil,
-			goof.Newf("error calling dmidecode: %s", stderr)
+		return "", goof.WithFieldE("stderr", stderr, "execute command failed", err)
+	} else if err != nil {
+		return "", goof.WithError("execute command failed", err)
 	}
-	return nil, goof.WithError("error calling dmidecode", err)
+	return string(out), nil
+}
+
+// the code of getInstanceIDFromConfigDrive is mostly copied from k8s OpenStack driver
+// https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/openstack/metadata.go
+// Copyright to the original authors (Apache license)
+
+// Config drive is defined as an iso9660 or vfat (deprecated) drive
+// with the "config-2" label.
+// http://docs.openstack.org/user-guide/cli-config-drive.html
+const configDriveLabel = "config-2"
+const configDrivePath = "openstack/latest/meta_data.json"
+
+func getInstanceIDFromConfigDrive(ctx types.Context, d *driver) (string, error) {
+	// Try to read instance UUID from config drive.
+	dev := "/dev/disk/by-label/" + configDriveLabel
+	if _, err := os.Stat(dev); os.IsNotExist(err) {
+		cmdOut, err := execCommand(
+			"blkid", "-l",
+			"-t", "LABEL="+configDriveLabel,
+			"-o", "device",
+		)
+
+		if err != nil {
+			return "", goof.WithError("Unable to run blkid", err)
+		}
+		dev = strings.TrimSpace(string(cmdOut))
+	}
+
+	mntdir, err := ioutil.TempDir("", "configdrive")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(mntdir)
+
+	mountOpts := types.DeviceMountOpts{
+		FsType:       "iso9660",
+		MountOptions: "ro",
+	}
+	err = d.osDriver.Mount(ctx, dev, mntdir, &mountOpts)
+	if err != nil {
+		mountOpts.FsType = "vfat"
+		err = d.osDriver.Mount(ctx, dev, mntdir, &mountOpts)
+	}
+	if err != nil {
+		return "", goof.WithFieldE("device", dev, "error mounting configdrive", err)
+	}
+	defer d.osDriver.Unmount(ctx, mntdir, utils.NewStore())
+
+	metadataBytes, err := ioutil.ReadFile(filepath.Join(mntdir, configDrivePath))
+	if err != nil {
+		return "", goof.WithError("error reading metadata file on config drive", err)
+	}
+
+	return parseUUID(metadataBytes)
+}
+
+func getInstanceIDFromMetadataServer() (string, error) {
+	const metadataURL = "http://169.254.169.254/openstack/latest/meta_data.json"
+	httpClient := http.Client{
+		Timeout: time.Duration(5 * time.Second),
+	}
+
+	resp, err := httpClient.Get(metadataURL)
+	if err != nil {
+		return "", goof.WithFieldE("url", metadataURL, "error getting metadata from server", err)
+	}
+	defer resp.Body.Close()
+
+	metadataBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", goof.WithError("io error reading metadata", err)
+	}
+
+	return parseUUID(metadataBytes)
+}
+
+func getInstanceIDWithDMIDecode() (string, error) {
+	cmdOut, err := execCommand("dmidecode", "-t", "system")
+	if err != nil {
+		return "", goof.WithError("error calling dmidecode", err)
+	}
 
 	rp := regexp.MustCompile("UUID:(.*)")
 	uuid := strings.Replace(rp.FindString(string(cmdOut)), "UUID: ", "", -1)

--- a/drivers/storage/openstack/executor/openstack_executor.go
+++ b/drivers/storage/openstack/executor/openstack_executor.go
@@ -1,0 +1,153 @@
+package executor
+
+import (
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/goof"
+
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/drivers/storage/openstack"
+
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+type driver struct {
+	config gofig.Config
+}
+
+func init() {
+	registry.RegisterStorageExecutor(openstack.Name, newDriver)
+}
+
+func newDriver() types.StorageExecutor {
+	return &driver{}
+}
+
+func (d *driver) Init(ctx types.Context, config gofig.Config) error {
+	d.config = config
+	return nil
+}
+
+func (d *driver) Name() string {
+	return openstack.Name
+}
+
+func (d *driver) InstanceID(
+	ctx types.Context,
+	opts types.Store) (*types.InstanceID, error) {
+
+	uuid, err := getInstanceIDFromMetadataServer()
+	if err != nil {
+		metadataServerErr := err
+		uuid, err = getInstanceIDFromCloudInitFile()
+		if err != nil {
+			cloudInitFileErr := err
+			uuid, err = getInstanceIDWithDMIDecode()
+			if err != nil {
+				return nil, fmt.Errorf("%v ; %v ; %v", cloudInitFileErr, metadataServerErr, err)
+			}
+		}
+	}
+
+	iid := &types.InstanceID{Driver: openstack.Name, ID: strings.ToLower(uuid)}
+
+	return iid, nil
+}
+
+func getInstanceIDFromCloudInitFile() (string, error) {
+	const instanceIDFile = "/var/lib/cloud/data/instance-id"
+	idBytes, err := ioutil.ReadFile(instanceIDFile)
+	if err != nil {
+		return "", goof.WithError("error reading file "+instanceIDFile, err)
+	}
+
+	instanceID := string(idBytes)
+	instanceID = strings.TrimSpace(instanceID)
+
+	return instanceID, nil
+}
+
+func getInstanceIDFromMetadataServer() (string, error) {
+	const metadataURL = "http://169.254.169.254/openstack/latest/meta_data.json"
+	resp, err := http.Get(metadataURL)
+	if err != nil {
+		return "", goof.WithError("error getting metadata from "+metadataURL, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", goof.WithError("io error reading metadata", err)
+	}
+	var decodedJSON interface{}
+	err = json.Unmarshal(data, &decodedJSON)
+	if err != nil {
+		return "", goof.WithError("error unmarshalling metadata", err)
+	}
+	decodedJSONMap, ok := decodedJSON.(map[string]interface{})
+	if !ok {
+		return "", goof.New("error casting metadata decoded JSON")
+	}
+	uuid, ok := decodedJSONMap["uuid"].(string)
+	if !ok {
+		return "", goof.New("error casting metadata uuid field")
+	}
+
+	return uuid, nil
+}
+
+func getInstanceIDWithDMIDecode() (string, error) {
+	cmd := exec.Command("dmidecode", "-t", "system")
+	cmdOut, err := cmd.Output()
+
+	if err != nil {
+		return "", goof.WithError("error calling dmidecode", err)
+	}
+
+	rp := regexp.MustCompile("UUID:(.*)")
+	uuid := strings.Replace(rp.FindString(string(cmdOut)), "UUID: ", "", -1)
+
+	return strings.ToLower(uuid), nil
+}
+
+func (d *driver) NextDevice(
+	ctx types.Context,
+	opts types.Store) (string, error) {
+	return "", types.ErrNotImplemented
+}
+
+func (d *driver) LocalDevices(
+	ctx types.Context,
+	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
+	devicesMap := make(map[string]string)
+
+	file := "/proc/partitions"
+	contentBytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(
+				goof.Fields{"file": file}, "error reading file", err)
+	}
+
+	content := string(contentBytes)
+
+	lines := strings.Split(content, "\n")
+	for _, line := range lines[2:] {
+		fields := strings.Fields(line)
+		if len(fields) >= 4 {
+			devicePath := "/dev/" + fields[3]
+			devicesMap[devicePath] = ""
+		}
+	}
+
+	return &types.LocalDevices{
+		Driver:    openstack.Name,
+		DeviceMap: devicesMap,
+	}, nil
+}

--- a/drivers/storage/openstack/executor/openstack_executor.go
+++ b/drivers/storage/openstack/executor/openstack_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_openstack
+
 package executor
 
 import (
@@ -36,6 +38,13 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 
 func (d *driver) Name() string {
 	return openstack.Name
+}
+
+// InstanceID returns the local instance ID for the test
+func InstanceID(config gofig.Config) (*types.InstanceID, error) {
+	d := newDriver()
+	d.Init(nil, config)
+	return d.InstanceID(nil, nil)
 }
 
 func (d *driver) InstanceID(

--- a/drivers/storage/openstack/openstack.go
+++ b/drivers/storage/openstack/openstack.go
@@ -16,6 +16,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", "openstack.userID")
 	r.Key(gofig.String, "", "", "", "openstack.userName")
 	r.Key(gofig.String, "", "", "", "openstack.password")
+	r.Key(gofig.String, "", "", "", "openstack.tokenID")
 	r.Key(gofig.String, "", "", "", "openstack.tenantID")
 	r.Key(gofig.String, "", "", "", "openstack.tenantName")
 	r.Key(gofig.String, "", "", "", "openstack.domainID")

--- a/drivers/storage/openstack/openstack.go
+++ b/drivers/storage/openstack/openstack.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_openstack
+
 package openstack
 
 import (
@@ -5,16 +7,10 @@ import (
 	gofig "github.com/akutz/gofig/types"
 )
 
-const (
-	// Name is the provider's name.
-	Name = "openstack"
-)
+// Name is the provider's name.
+const Name string = "openstack"
 
 func init() {
-	registerConfig()
-}
-
-func registerConfig() {
 	r := gofigCore.NewRegistration("OpenStack")
 	r.Key(gofig.String, "", "", "", "openstack.authURL")
 	r.Key(gofig.String, "", "", "", "openstack.userID")

--- a/drivers/storage/openstack/openstack.go
+++ b/drivers/storage/openstack/openstack.go
@@ -1,0 +1,30 @@
+package openstack
+
+import (
+	gofigCore "github.com/akutz/gofig"
+	gofig "github.com/akutz/gofig/types"
+)
+
+const (
+	// Name is the provider's name.
+	Name = "openstack"
+)
+
+func init() {
+	registerConfig()
+}
+
+func registerConfig() {
+	r := gofigCore.NewRegistration("OpenStack")
+	r.Key(gofig.String, "", "", "", "openstack.authURL")
+	r.Key(gofig.String, "", "", "", "openstack.userID")
+	r.Key(gofig.String, "", "", "", "openstack.userName")
+	r.Key(gofig.String, "", "", "", "openstack.password")
+	r.Key(gofig.String, "", "", "", "openstack.tenantID")
+	r.Key(gofig.String, "", "", "", "openstack.tenantName")
+	r.Key(gofig.String, "", "", "", "openstack.domainID")
+	r.Key(gofig.String, "", "", "", "openstack.domainName")
+	r.Key(gofig.String, "", "", "", "openstack.regionName")
+	r.Key(gofig.String, "", "", "", "openstack.availabilityZoneName")
+	gofigCore.Register(r)
+}

--- a/drivers/storage/openstack/storage/openstack_storage.go
+++ b/drivers/storage/openstack/storage/openstack_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_openstack
+
 package openstack
 
 import (

--- a/drivers/storage/openstack/storage/openstack_storage.go
+++ b/drivers/storage/openstack/storage/openstack_storage.go
@@ -89,6 +89,11 @@ func (d *driver) Init(context types.Context, config gofig.Config) error {
 	} else {
 		fields["password"] = "******"
 	}
+	if d.tokenID() == "" {
+		fields["tokenId"] = ""
+	} else {
+		fields["tokenId"] = "******"
+	}
 	fields["tenantId"] = d.tenantID()
 	fields["tenantName"] = d.tenantName()
 	fields["domainId"] = d.domainID()
@@ -154,6 +159,7 @@ func (d *driver) getAuthOptions() gophercloud.AuthOptions {
 		UserID:           d.userID(),
 		Username:         d.userName(),
 		Password:         d.password(),
+		TokenID:          d.tokenID(),
 		TenantID:         d.tenantID(),
 		TenantName:       d.tenantName(),
 		DomainID:         d.domainID(),
@@ -682,6 +688,10 @@ func (d *driver) userName() string {
 
 func (d *driver) password() string {
 	return d.config.GetString("openstack.password")
+}
+
+func (d *driver) tokenID() string {
+	return d.config.GetString("openstack.tokenID")
 }
 
 func (d *driver) tenantID() string {

--- a/drivers/storage/openstack/storage/openstack_storage.go
+++ b/drivers/storage/openstack/storage/openstack_storage.go
@@ -587,8 +587,13 @@ func (d *driver) VolumeAttach(
 	})
 
 	if opts.Force {
-		if _, err := d.VolumeDetach(ctx, volumeID, &types.VolumeDetachOpts{}); err != nil {
-			return nil, "", err
+		// check if attached before trying a detach
+		if vol, err := d.VolumeInspect(ctx, volumeID, &types.VolumeInspectOpts{Attachments: types.VolAttReq}); err == nil {
+			if len(vol.Attachments) > 0 {
+				if _, err := d.VolumeDetach(ctx, volumeID, &types.VolumeDetachOpts{}); err != nil {
+					return nil, "", err
+				}
+			}
 		}
 	}
 

--- a/drivers/storage/openstack/storage/openstack_storage.go
+++ b/drivers/storage/openstack/storage/openstack_storage.go
@@ -1,0 +1,633 @@
+package openstack
+
+import (
+	"time"
+
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/goof"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	openstackdriver "github.com/codedellemc/libstorage/drivers/storage/openstack"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+	"github.com/rackspace/gophercloud/openstack/blockstorage/v1/snapshots"
+	"github.com/rackspace/gophercloud/openstack/blockstorage/v2/extensions/volumeactions"
+	"github.com/rackspace/gophercloud/openstack/blockstorage/v2/volumes"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
+	"github.com/rackspace/gophercloud/openstack/identity/v3/extensions/trust"
+	token3 "github.com/rackspace/gophercloud/openstack/identity/v3/tokens"
+)
+
+type driver struct {
+	provider             *gophercloud.ProviderClient
+	clientCompute        *gophercloud.ServiceClient
+	clientBlockStorage   *gophercloud.ServiceClient
+	clientBlockStoragev2 *gophercloud.ServiceClient
+	availabilityZone     string
+	config               gofig.Config
+}
+
+func ef() goof.Fields {
+	return goof.Fields{
+		"provider": openstackdriver.Name,
+	}
+}
+
+func eff(fields goof.Fields) map[string]interface{} {
+	errFields := map[string]interface{}{
+		"provider": openstackdriver.Name,
+	}
+	if fields != nil {
+		for k, v := range fields {
+			errFields[k] = v
+		}
+	}
+	return errFields
+}
+
+func init() {
+	registry.RegisterStorageDriver(openstackdriver.Name, newDriver)
+}
+
+func newDriver() types.StorageDriver {
+	return &driver{}
+}
+
+func (d *driver) Name() string {
+	return openstackdriver.Name
+}
+
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+	return types.Block, nil
+}
+
+func (d *driver) Init(context types.Context, config gofig.Config) error {
+	d.config = config
+	fields := eff(map[string]interface{}{})
+	var err error
+
+	endpointOpts := gophercloud.EndpointOpts{}
+
+	endpointOpts.Region = d.regionName()
+	fields["region"] = endpointOpts.Region
+
+	d.availabilityZone = d.availabilityZoneName()
+	fields["availabilityZone"] = d.availabilityZone
+
+	authOpts := d.getAuthOptions()
+
+	fields["identityEndpoint"] = d.authURL()
+	fields["userId"] = d.userID()
+	fields["userName"] = d.userName()
+	if d.password() == "" {
+		fields["password"] = ""
+	} else {
+		fields["password"] = "******"
+	}
+	fields["tenantId"] = d.tenantID()
+	fields["tenantName"] = d.tenantName()
+	fields["domainId"] = d.domainID()
+	fields["domainName"] = d.domainName()
+
+	trustID := d.trustID()
+	fields["trustId"] = trustID
+
+	d.provider, err = openstack.NewClient(authOpts.IdentityEndpoint)
+	if err != nil {
+		return goof.WithFieldsE(fields, "error creating Keystone client", err)
+	}
+
+	if trustID != "" {
+		authOptionsExt := trust.AuthOptionsExt{
+			TrustID:     trustID,
+			AuthOptions: token3.AuthOptions{AuthOptions: authOpts},
+		}
+		err = trust.AuthenticateV3Trust(d.provider, authOptionsExt)
+	} else {
+		err = openstack.Authenticate(d.provider, authOpts)
+	}
+	if err != nil {
+		return goof.WithFieldsE(fields, "error authenticating", err)
+	}
+
+	if d.clientCompute, err = openstack.NewComputeV2(d.provider, endpointOpts); err != nil {
+		return goof.WithFieldsE(fields, "error getting newComputeV2", err)
+	}
+
+	if d.clientBlockStorage, err = openstack.NewBlockStorageV1(d.provider, endpointOpts); err != nil {
+		return goof.WithFieldsE(fields, "error getting newBlockStorageV1", err)
+	}
+
+	if d.clientBlockStoragev2, err = openstack.NewBlockStorageV2(d.provider, endpointOpts); err != nil {
+		return goof.WithFieldsE(fields, "error getting newBlockStorageV2", err)
+	}
+
+	context.WithFields(fields).Info("storage driver initialized")
+
+	return nil
+}
+
+// InstanceInspect returns an instance.
+func (d *driver) InstanceInspect(
+	ctx types.Context,
+	opts types.Store) (*types.Instance, error) {
+
+	iid := context.MustInstanceID(ctx)
+	if iid.ID != "" {
+		return &types.Instance{InstanceID: iid}, nil
+	}
+
+	return nil, goof.New("Can create an instance without an instanceID")
+}
+
+func (d *driver) getAuthOptions() gophercloud.AuthOptions {
+	return gophercloud.AuthOptions{
+		IdentityEndpoint: d.authURL(),
+		UserID:           d.userID(),
+		Username:         d.userName(),
+		Password:         d.password(),
+		TenantID:         d.tenantID(),
+		TenantName:       d.tenantName(),
+		DomainID:         d.domainID(),
+		DomainName:       d.domainName(),
+		AllowReauth:      true,
+	}
+}
+
+func (d *driver) Volumes(
+	ctx types.Context,
+	opts *types.VolumesOpts) ([]*types.Volume, error) {
+
+	allPages, err := volumes.List(d.clientBlockStoragev2, nil).AllPages()
+	if err != nil {
+		return nil,
+			goof.WithError("error listing volumes", err)
+	}
+	volumesOS, err := volumes.ExtractVolumes(allPages)
+	if err != nil {
+		return nil,
+			goof.WithError("error listing volumes", err)
+	}
+
+	var volumesRet []*types.Volume
+	for _, volumeOS := range volumesOS {
+		volumesRet = append(volumesRet, translateVolume(&volumeOS, true))
+	}
+
+	return volumesRet, nil
+}
+
+func (d *driver) VolumeInspect(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	fields := eff(goof.Fields{
+		"volumeId": volumeID,
+	})
+
+	if volumeID == "" {
+		return nil, goof.New("no volumeID specified")
+	}
+
+	volume, err := volumes.Get(d.clientBlockStoragev2, volumeID).Extract()
+
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(fields, "error getting volume", err)
+	}
+
+	return translateVolume(volume, opts.Attachments), nil
+}
+
+func translateVolume(volume *volumes.Volume, includeAttachments bool) *types.Volume {
+	var attachments []*types.VolumeAttachment
+	if includeAttachments {
+		for _, attachment := range volume.Attachments {
+			libstorageAttachment := &types.VolumeAttachment{
+				VolumeID:   attachment["volume_id"].(string),
+				InstanceID: &types.InstanceID{ID: attachment["server_id"].(string), Driver: openstackdriver.Name},
+				DeviceName: attachment["device"].(string),
+				Status:     "",
+			}
+			attachments = append(attachments, libstorageAttachment)
+		}
+	}
+
+	return &types.Volume{
+		Name:             volume.Name,
+		ID:               volume.ID,
+		AvailabilityZone: volume.AvailabilityZone,
+		Status:           volume.Status,
+		Type:             volume.VolumeType,
+		IOPS:             0,
+		Size:             int64(volume.Size),
+		Attachments:      attachments,
+	}
+}
+
+func (d *driver) SnapshotInspect(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	fields := eff(map[string]interface{}{
+		"snapshotId": snapshotID,
+	})
+
+	snapshot, err := snapshots.Get(d.clientBlockStorage, snapshotID).Extract()
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(fields, "error getting snapshot", err)
+	}
+
+	return translateSnapshot(snapshot), nil
+}
+
+func (d *driver) Snapshots(
+	ctx types.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+	allPages, err := snapshots.List(d.clientBlockStorage, nil).AllPages()
+	if err != nil {
+		return []*types.Snapshot{},
+			goof.WithError("error listing volume snapshots", err)
+	}
+	allSnapshots, err := snapshots.ExtractSnapshots(allPages)
+	if err != nil {
+		return []*types.Snapshot{},
+			goof.WithError("error listing volume snapshots", err)
+	}
+
+	var libstorageSnapshots []*types.Snapshot
+	for _, snapshot := range allSnapshots {
+		libstorageSnapshots = append(libstorageSnapshots, translateSnapshot(&snapshot))
+	}
+
+	return libstorageSnapshots, nil
+}
+
+func translateSnapshot(snapshot *snapshots.Snapshot) *types.Snapshot {
+	createAtEpoch := int64(0)
+	createdAt, err := time.Parse(time.RFC3339Nano, snapshot.CreatedAt)
+	if err == nil {
+		createAtEpoch = createdAt.Unix()
+	}
+	return &types.Snapshot{
+		Name:        snapshot.Name,
+		VolumeID:    snapshot.VolumeID,
+		ID:          snapshot.ID,
+		VolumeSize:  int64(snapshot.Size),
+		StartTime:   createAtEpoch,
+		Description: snapshot.Description,
+		Status:      snapshot.Status,
+	}
+}
+
+func (d *driver) VolumeSnapshot(
+	ctx types.Context,
+	volumeID, snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	fields := eff(map[string]interface{}{
+		"snapshotName": snapshotName,
+		"volumeId":     volumeID,
+	})
+
+	createOpts := snapshots.CreateOpts{
+		Name:     snapshotName,
+		VolumeID: volumeID,
+		Force:    true,
+	}
+
+	snapshot, err := snapshots.Create(d.clientBlockStorage, createOpts).Extract()
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(fields, "error creating snapshot", err)
+	}
+
+	ctx.WithFields(fields).Info("waiting for snapshot creation to complete")
+
+	err = snapshots.WaitForStatus(d.clientBlockStorage, snapshot.ID, "available", int(d.volumeSnapshotTimeout().Seconds()))
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(fields,
+				"error waiting for snapshot creation to complete", err)
+	}
+
+	return translateSnapshot(snapshot), nil
+
+}
+
+func (d *driver) SnapshotRemove(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) error {
+	resp := snapshots.Delete(d.clientBlockStorage, snapshotID)
+	if resp.Err != nil {
+		return goof.WithFieldsE(goof.Fields{
+			"snapshotId": snapshotID}, "error removing snapshot", resp.Err)
+	}
+
+	return nil
+}
+
+func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	return d.createVolume(ctx, volumeName, "", "", opts)
+}
+
+func (d *driver) VolumeCreateFromSnapshot(
+	ctx types.Context,
+	snapshotID, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	return d.createVolume(ctx, volumeName, "", snapshotID, opts)
+}
+
+func (d *driver) VolumeCopy(
+	ctx types.Context,
+	volumeID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+	volume, err := d.VolumeInspect(ctx, volumeID, &types.VolumeInspectOpts{})
+	if err != nil {
+		return nil,
+			goof.New("error getting reference volume for volume copy")
+	}
+
+	volumeCreateOpts := &types.VolumeCreateOpts{
+		Type:             &volume.Type,
+		AvailabilityZone: &volume.AvailabilityZone,
+	}
+
+	return d.createVolume(ctx, volumeName, volumeID, "", volumeCreateOpts)
+}
+
+func (d *driver) createVolume(
+	ctx types.Context,
+	volumeName string,
+	volumeSourceID string,
+	snapshotID string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+	volumeType := *opts.Type
+	IOPS := *opts.IOPS
+	size := *opts.Size
+	availabilityZone := *opts.AvailabilityZone
+
+	fields := eff(map[string]interface{}{
+		"volumeName":       volumeName,
+		"snapshotId":       snapshotID,
+		"volumeSourceId":   volumeSourceID,
+		"volumeType":       volumeType,
+		"iops":             IOPS,
+		"size":             size,
+		"availabilityZone": availabilityZone,
+	})
+
+	if availabilityZone == "" {
+		availabilityZone = d.availabilityZone
+	}
+
+	options := &volumes.CreateOpts{
+		Name:             volumeName,
+		Size:             int(size),
+		SnapshotID:       snapshotID,
+		VolumeType:       volumeType,
+		AvailabilityZone: availabilityZone,
+		SourceReplica:    volumeSourceID,
+	}
+	volume, err := volumes.Create(d.clientBlockStoragev2, options).Extract()
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(fields, "error creating volume", err)
+	}
+
+	fields["volumeId"] = volume.ID
+
+	ctx.WithFields(fields).Info("waiting for volume creation to complete")
+	err = volumes.WaitForStatus(d.clientBlockStoragev2, volume.ID, "available", int(d.volumeCreateTimeout().Seconds()))
+	if err != nil {
+		return nil,
+			goof.WithFieldsE(fields,
+				"error waiting for volume creation to complete", err)
+	}
+
+	return translateVolume(volume, true), nil
+}
+
+func (d *driver) VolumeRemove(
+	ctx types.Context,
+	volumeID string,
+	opts types.Store) error {
+	fields := eff(map[string]interface{}{
+		"volumeId": volumeID,
+	})
+	if volumeID == "" {
+		return goof.WithFields(fields, "volumeId is required")
+	}
+	res := volumes.Delete(d.clientBlockStoragev2, volumeID)
+	if res.Err != nil {
+		return goof.WithFieldsE(fields, "error removing volume", res.Err)
+	}
+
+	return nil
+}
+
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeAttach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
+
+	iid := context.MustInstanceID(ctx)
+
+	fields := eff(map[string]interface{}{
+		"volumeId":   volumeID,
+		"instanceId": iid.ID,
+	})
+
+	if opts.Force {
+		if _, err := d.VolumeDetach(ctx, volumeID, &types.VolumeDetachOpts{}); err != nil {
+			return nil, "", err
+		}
+	}
+
+	options := &volumeattach.CreateOpts{
+		VolumeID: volumeID,
+	}
+	if opts.NextDevice != nil {
+		options.Device = *opts.NextDevice
+	}
+
+	volumeAttach, err := volumeattach.Create(d.clientCompute, iid.ID, options).Extract()
+	if err != nil {
+		return nil, "", goof.WithFieldsE(
+			fields, "error attaching volume", err)
+	}
+
+	ctx.WithFields(fields).Debug("waiting for volume to attach")
+	volume, err := d.waitVolumeAttachStatus(ctx, volumeID, true, 30*time.Second)
+	if err != nil {
+		return nil, "", goof.WithFieldsE(
+			fields, "error waiting for volume to attach", err)
+	}
+
+	return volume, volumeAttach.Device, nil
+}
+
+func (d *driver) VolumeDetach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeDetachOpts) (*types.Volume, error) {
+
+	iid := context.MustInstanceID(ctx)
+
+	fields := eff(map[string]interface{}{
+		"volumeId":   volumeID,
+		"instanceId": iid.ID,
+	})
+
+	if volumeID == "" {
+		return nil, goof.WithFields(fields, "volumeId is required")
+	}
+
+	resp := volumeattach.Delete(d.clientCompute, iid.ID, volumeID)
+	if resp.Err != nil {
+		return nil, goof.WithFieldsE(fields, "error detaching volume", resp.Err)
+	}
+
+	ctx.WithFields(fields).Debug("waiting for volume to detach")
+	volume, err := d.waitVolumeAttachStatus(ctx, volumeID, false, 30*time.Second)
+	if err == nil {
+		return volume, nil
+	}
+
+	if opts.Force {
+		resp := volumeactions.Detach(d.clientBlockStoragev2, volumeID)
+
+		if resp.Err != nil {
+			return nil, goof.WithFieldsE(fields, "error force detaching volume", resp.Err)
+		}
+
+		volume, err = d.waitVolumeAttachStatus(ctx, volumeID, false, 30*time.Second)
+		if err != nil {
+			return nil, goof.WithFieldsE(
+				fields, "error waiting for volume to force detach", err)
+		}
+
+		return volume, nil
+	}
+
+	return nil, goof.WithFields(fields, "unexpected error when detaching")
+}
+
+func (d *driver) waitVolumeAttachStatus(ctx types.Context, volumeID string, attachmentNeeded bool, timeout time.Duration) (*types.Volume, error) {
+
+	fields := eff(map[string]interface{}{
+		"volumeId": volumeID,
+	})
+
+	if volumeID == "" {
+		return nil, goof.WithFields(fields, "volumeId is required")
+	}
+	begin := time.Now()
+	for time.Now().Sub(begin) < timeout {
+		volume, err := d.VolumeInspect(ctx, volumeID, &types.VolumeInspectOpts{Attachments: true})
+		if err != nil {
+			return nil, goof.WithFieldsE(fields, "error getting volume when waiting", err)
+		}
+
+		if attachmentNeeded {
+			if len(volume.Attachments) > 0 {
+				return volume, nil
+			}
+		} else {
+			if len(volume.Attachments) == 0 {
+				return volume, nil
+			}
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return nil, goof.WithFields(fields, "timeout reached")
+}
+
+func (d *driver) SnapshotCopy(
+	ctx types.Context,
+	snapshotID, snapshotName, destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+	// TODO return nil, nil ?
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) authURL() string {
+	return d.config.GetString("openstack.authURL")
+}
+
+func (d *driver) userID() string {
+	return d.config.GetString("openstack.userID")
+}
+
+func (d *driver) userName() string {
+	return d.config.GetString("openstack.userName")
+}
+
+func (d *driver) password() string {
+	return d.config.GetString("openstack.password")
+}
+
+func (d *driver) tenantID() string {
+	return d.config.GetString("openstack.tenantID")
+}
+
+func (d *driver) tenantName() string {
+	return d.config.GetString("openstack.tenantName")
+}
+
+func (d *driver) domainID() string {
+	return d.config.GetString("openstack.domainID")
+}
+
+func (d *driver) domainName() string {
+	return d.config.GetString("openstack.domainName")
+}
+
+func (d *driver) regionName() string {
+	return d.config.GetString("openstack.regionName")
+}
+
+func (d *driver) availabilityZoneName() string {
+	return d.config.GetString("openstack.availabilityZoneName")
+}
+
+func (d *driver) trustID() string {
+	return d.config.GetString("openstack.trustID")
+}
+
+func (d *driver) volumeCreateTimeout() time.Duration {
+	strVal := d.config.GetString("openstack.volumeCreateTimeout")
+	val, err := time.ParseDuration(strVal)
+
+	if err != nil || val <= 0 {
+		val = 10 * time.Minute
+	}
+	return val
+}
+
+func (d *driver) volumeSnapshotTimeout() time.Duration {
+	strVal := d.config.GetString("openstack.volumeSnapshotTimeout")
+	val, err := time.ParseDuration(strVal)
+
+	if err != nil || val <= 0 {
+		val = 10 * time.Minute
+	}
+	return val
+}

--- a/drivers/storage/openstack/storage/openstack_storage.go
+++ b/drivers/storage/openstack/storage/openstack_storage.go
@@ -753,22 +753,12 @@ func (d *driver) trustID() string {
 	return d.config.GetString("openstack.trustID")
 }
 
-func (d *driver) timeout() time.Duration {
-	strVal := d.config.GetString("openstack.timeout")
-	val, err := time.ParseDuration(strVal)
-
-	if err != nil || val <= 0 {
-		val = 10 * time.Minute
-	}
-	return val
-}
-
 func (d *driver) attachTimeout() time.Duration {
 	strVal := d.config.GetString("openstack.attachTimeout")
 	val, err := time.ParseDuration(strVal)
 
 	if err != nil || val <= 0 {
-		val = d.timeout()
+		val = 1 * time.Minute
 	}
 	return val
 }
@@ -778,7 +768,7 @@ func (d *driver) deleteTimeout() time.Duration {
 	val, err := time.ParseDuration(strVal)
 
 	if err != nil || val <= 0 {
-		val = d.timeout()
+		val = 10 * time.Minute
 	}
 	return val
 }
@@ -788,7 +778,7 @@ func (d *driver) createTimeout() time.Duration {
 	val, err := time.ParseDuration(strVal)
 
 	if err != nil || val <= 0 {
-		val = d.timeout()
+		val = 10 * time.Minute
 	}
 	return val
 }
@@ -798,7 +788,7 @@ func (d *driver) snapshotTimeout() time.Duration {
 	val, err := time.ParseDuration(strVal)
 
 	if err != nil || val <= 0 {
-		val = d.timeout()
+		val = 10 * time.Minute
 	}
 	return val
 }

--- a/drivers/storage/openstack/tests/coverage.mk
+++ b/drivers/storage/openstack/tests/coverage.mk
@@ -1,0 +1,2 @@
+OPENSTACK_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/openstack
+TEST_COVERPKG_./drivers/storage/openstack/tests := $(OPENSTACK_COVERPKG),$(OPENSTACK_COVERPKG)/executor

--- a/drivers/storage/openstack/tests/openstack_test.go
+++ b/drivers/storage/openstack/tests/openstack_test.go
@@ -1,0 +1,534 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_openstack
+
+package openstack
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	gofig "github.com/akutz/gofig/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/server"
+	apitests "github.com/codedellemc/libstorage/api/tests"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/api/utils"
+
+	// load the driver
+	openstack "github.com/codedellemc/libstorage/drivers/storage/openstack"
+	openstackx "github.com/codedellemc/libstorage/drivers/storage/openstack/executor"
+)
+
+// configYAML is an embedded config file that specifies the bare minimum
+// configuration for creating an openstack volume.
+var configYAML = []byte(`
+openstack:
+  authURL: ` + os.Getenv("OS_AUTH_URL") + `
+  username: ` + os.Getenv("OS_USERNAME") + `
+  tenantName: ` + os.Getenv("OS_TENANT_NAME") + `
+  domainName: ` + os.Getenv("OS_USER_DOMAIN_NAME") + `
+  password: ` + os.Getenv("OS_PASSWORD") + `
+  availabilityZoneName: ` + os.Getenv("OS_AVAILABILITY_ZONE") + `
+  regionName: ` + os.Getenv("OS_REGION_NAME") + `
+`)
+
+var volumeName string
+var volumeName2 string
+
+func skipTests() bool {
+	travis, _ := strconv.ParseBool(os.Getenv("TRAVIS"))
+	noTest, _ := strconv.ParseBool(os.Getenv("TEST_SKIP_OPENSTACK"))
+	return travis || noTest
+}
+
+func init() {
+	// set the volumeName to a random name
+	uuid, _ := types.NewUUID()
+	uuids := strings.Split(uuid.String(), "-")
+	volumeName = uuids[0]
+
+	// set the second volumeName to a random name
+	uuid, _ = types.NewUUID()
+	uuids = strings.Split(uuid.String(), "-")
+	volumeName2 = uuids[0]
+}
+
+func TestMain(m *testing.M) {
+	server.CloseOnAbort()
+	ec := m.Run()
+	os.Exit(ec)
+}
+
+func TestInstanceID(t *testing.T) { //PASSES lowercase hidden for testing other stuff
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	sd, err := registry.NewStorageDriver(openstack.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	configR := registry.NewConfig()
+	if err := configR.ReadConfig(bytes.NewReader(configYAML)); err != nil {
+		panic(err)
+	}
+	if err := sd.Init(ctx, configR); err != nil {
+		t.Fatal(err)
+	}
+	iid, err := openstackx.InstanceID(configR)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx = ctx.WithValue(context.InstanceIDKey, iid)
+	i, err := sd.InstanceInspect(ctx, utils.NewStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	iid = i.InstanceID
+
+	apitests.Run(
+		t, openstack.Name, configYAML,
+		(&apitests.InstanceIDTest{
+			Driver:   openstack.Name,
+			Expected: iid,
+		}).Test)
+}
+
+func TestServices(t *testing.T) { //PASSES lowercase hidden for testing other stuff
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Services(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, len(reply), 1)
+
+		_, ok := reply[openstack.Name]
+		assert.True(t, ok)
+	}
+	apitests.Run(t, openstack.Name, configYAML, tf)
+}
+
+func volumeByName(
+	t *testing.T, client types.Client, volumeName string) *types.Volume {
+
+	log.WithField("volumeName", volumeName).Info("get volume")
+	vols, err := client.API().Volumes(nil, 0)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+	assert.Contains(t, vols, openstack.Name)
+	for _, vol := range vols[openstack.Name] {
+		if vol.Name == volumeName {
+			return vol
+		}
+	}
+	t.FailNow()
+	t.Error("failed volumeByName")
+	return nil
+}
+
+func TestVolumeCreateRemove(t *testing.T) { //PASSES lowercase hidden for testing other stuff
+	if skipTests() {
+		t.SkipNow()
+	}
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol := volumeCreate(t, client, volumeName)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, openstack.Name, configYAML, tf)
+}
+
+func volumeCreate(
+	t *testing.T, client types.Client, volumeName string) *types.Volume {
+	log.WithField("volumeName", volumeName).Info("creating volume")
+	size := int64(1)
+
+	opts := map[string]interface{}{
+		"priority": 2,
+		"owner":    "root@example.com",
+	}
+
+	volumeCreateRequest := &types.VolumeCreateRequest{
+		Name: volumeName,
+		Size: &size,
+		Opts: opts,
+	}
+
+	reply, err := client.API().VolumeCreate(nil, openstack.Name, volumeCreateRequest)
+
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed volumeCreate")
+	}
+
+	apitests.LogAsJSON(reply, t)
+	assert.Equal(t, volumeName, reply.Name)
+	assert.Equal(t, int64(1), reply.Size)
+	return reply
+}
+
+func volumeRemove(t *testing.T, client types.Client, volumeID string) {
+	log.WithField("volumeID", volumeID).Info("removing volume")
+	err := client.API().VolumeRemove(
+		nil, openstack.Name, volumeID, false)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeRemove")
+		t.FailNow()
+	}
+}
+
+func TestVolumes(t *testing.T) { //PASSES lowercase hidden for testing other stuff
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		_ = volumeCreate(t, client, volumeName)
+		_ = volumeCreate(t, client, volumeName2)
+
+		vol1 := volumeByName(t, client, volumeName)
+		vol2 := volumeByName(t, client, volumeName2)
+
+		volumeRemove(t, client, vol1.ID)
+		volumeRemove(t, client, vol2.ID)
+	}
+	apitests.Run(t, openstack.Name, configYAML, tf)
+}
+
+func volumeAttach(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("attaching volume")
+	reply, token, err := client.API().VolumeAttach(
+		nil, openstack.Name, volumeID, &types.VolumeAttachRequest{})
+
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeAttach")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.NotEqual(t, token, "")
+
+	return reply
+}
+
+func volumeInspect(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(nil, openstack.Name, volumeID, 0)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed volumeInspect")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	return reply
+}
+
+func volumeInspectAttached(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(
+		nil, openstack.Name, volumeID, types.VolAttReqTrue)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed volumeInspectAttached")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 1)
+	return reply
+}
+
+func volumeInspectAttachedFail(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(
+		nil, openstack.Name, volumeID, types.VolAttReqTrue)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed volumeInspectAttachedFail")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 0)
+	return reply
+}
+
+func volumeInspectDetached(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(
+		nil, openstack.Name, volumeID, types.VolAttReqOnlyUnattachedVols)
+
+	if err != nil {
+		t.Error("failed volumeInspectDetached")
+		t.FailNow()
+	}
+	assert.NoError(t, err)
+
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 0)
+
+	return reply
+}
+
+func volumeInspectDetachedFail(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(nil, openstack.Name, volumeID, 0)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed volumeInspectDetachedFail")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 1)
+	apitests.LogAsJSON(reply, t)
+	return reply
+}
+
+func volumeDetach(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("detaching volume")
+	reply, err := client.API().VolumeDetach(
+		nil, openstack.Name, volumeID, &types.VolumeDetachRequest{})
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeDetach")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 0)
+	return reply
+}
+
+func TestVolumeAttach(t *testing.T) { //PASSES lowercase hidden to test other stuff
+	if skipTests() {
+		t.SkipNow()
+	}
+	var vol *types.Volume
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol = volumeCreate(t, client, volumeName)
+		_ = volumeAttach(t, client, vol.ID)
+		_ = volumeInspectAttached(t, client, vol.ID)
+		//_ = volumeInspectDetachedFail(t, client, vol.ID)
+		_ = volumeDetach(t, client, vol.ID)
+		_ = volumeInspectDetached(t, client, vol.ID)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, openstack.Name, configYAML, tf)
+}
+
+func testSnapshots(t *testing.T) { //currently fails due to timeout lowercase privated for now
+	if skipTests() {
+		t.SkipNow()
+	}
+	var vol *types.Volume
+	var cvol *types.Volume
+	var snap *types.Snapshot
+	var csnap *types.Snapshot
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol = volumeCreate(t, client, volumeName)
+		snap = volumeSnapshot(t, client, vol.ID, "libstorage test snapshot")
+		_ = snapshotInspect(t, client, snap.ID)
+		_ = snapshotByName(t, client, "libstorage test snapshot")
+		csnap = snapshotCopy(t, client, snap.ID, "listorage snapshot copy", "DestinationID not used")
+		_ = snapshotInspect(t, client, csnap.ID)
+		cvol = volumeCreateFromSnapshot(t, client, snap.ID, volumeName2)
+		_ = volumeInspectDetached(t, client, cvol.ID)
+		volumeRemove(t, client, cvol.ID)
+		snapshotRemove(t, client, snap.ID)
+		snapshotRemove(t, client, csnap.ID)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, openstack.Name, configYAML, tf)
+}
+
+func snapshotInspect(
+	t *testing.T, client types.Client, snapshotID string) *types.Snapshot {
+	log.WithField("snapshotID", snapshotID).Info("inspecting snapshot")
+	reply, err := client.API().SnapshotInspect(nil, openstack.Name, snapshotID)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed snapshotInspect")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	return reply
+}
+
+func snapshotByName(
+	t *testing.T, client types.Client, snapshotName string) *types.Snapshot {
+	log.WithField("snapshotName", snapshotName).Info("get snapshotByName")
+	snapshots, err := client.API().Snapshots(nil)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+	assert.Contains(t, snapshots, openstack.Name)
+	for _, vol := range snapshots[openstack.Name] {
+		if vol.Name == snapshotName {
+			return vol
+		}
+	}
+	t.FailNow()
+	t.Error("failed snapshotByName")
+	return nil
+}
+
+func volumeSnapshot(
+	t *testing.T, client types.Client,
+	volumeID, snapshotName string) *types.Snapshot {
+	log.WithField("snapshotName", snapshotName).Info("creating snapshot")
+
+	/*
+		opts := map[string]interface{}{
+			"priority": 2,
+			"owner":    "root@example.com",
+		}*/
+
+	volumeSnapshotRequest := &types.VolumeSnapshotRequest{
+		SnapshotName: snapshotName,
+		//	Opts: opts,
+	}
+
+	reply, err := client.API().VolumeSnapshot(nil, openstack.Name,
+		volumeID, volumeSnapshotRequest)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed snapshotCreate")
+	}
+	apitests.LogAsJSON(reply, t)
+
+	assert.Equal(t, snapshotName, reply.Name)
+	assert.Equal(t, volumeID, reply.VolumeID)
+	return reply
+}
+
+func snapshotCopy(
+	t *testing.T, client types.Client,
+	snapshotID, snapshotName, destinationID string) *types.Snapshot {
+	log.WithField("snapshotName", snapshotName).Info("copying snapshot")
+
+	snapshotCopyRequest := &types.SnapshotCopyRequest{
+		SnapshotName: snapshotName,
+	}
+
+	reply, err := client.API().SnapshotCopy(nil, openstack.Name,
+		snapshotID, snapshotCopyRequest)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed snapshotCopy")
+	}
+	apitests.LogAsJSON(reply, t)
+
+	assert.Equal(t, snapshotName, reply.Name)
+	return reply
+}
+
+func snapshotRemove(t *testing.T, client types.Client, snapshotID string) {
+	log.WithField("snapshotID", snapshotID).Info("removing snapshot")
+	err := client.API().SnapshotRemove(
+		nil, openstack.Name, snapshotID)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed snapshotRemove")
+		t.FailNow()
+	}
+}
+
+func volumeCreateFromSnapshot(
+	t *testing.T, client types.Client,
+	snapshotID, volumeName string) *types.Volume {
+	fields := map[string]interface{}{
+		"snapshotID": snapshotID,
+		"volumeName": volumeName,
+	}
+	log.WithFields(fields).Info("creating volume from snapshot")
+	size := int64(8)
+
+	opts := map[string]interface{}{
+		"priority": 2,
+		"owner":    "root@example.com",
+	}
+
+	volumeCreateRequest := &types.VolumeCreateRequest{
+		Name: volumeName,
+		Size: &size,
+		Opts: opts,
+	}
+
+	reply, err := client.API().VolumeCreateFromSnapshot(nil,
+		openstack.Name, snapshotID, volumeCreateRequest)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed volumeCreateFromSnapshot")
+	}
+	apitests.LogAsJSON(reply, t)
+
+	assert.Equal(t, volumeName, reply.Name)
+	assert.Equal(t, size, reply.Size)
+	assert.Equal(t, opts["priority"], 2)
+	assert.Equal(t, opts["owner"], "root@example.com")
+
+	return reply
+}
+
+func volumeCopy(
+	t *testing.T, client types.Client,
+	volumeID, volumeName string) *types.Volume {
+	fields := map[string]interface{}{
+		"volumeID":   volumeID,
+		"volumeName": volumeName,
+	}
+	log.WithFields(fields).Info("copying volume")
+
+	volumeCopyRequest := &types.VolumeCopyRequest{
+		VolumeName: volumeName,
+	}
+
+	reply, err := client.API().VolumeCopy(nil,
+		openstack.Name, volumeID, volumeCopyRequest)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed volumeCopy")
+	}
+	apitests.LogAsJSON(reply, t)
+
+	assert.Equal(t, volumeName, reply.Name)
+
+	return reply
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,11 +1,10 @@
-hash: 6b3161a1086d56cfb657e5b47370ed70cce0aa592d1b095cb885c3e4763f1eb5
-updated: 2017-04-20T15:53:52.320351451-05:00
+hash: ef685cedda69acd66247f7a8a87055134af1e2df8e7c0a7760a3dd0b18c9f637
+updated: 2017-04-24T17:06:40.407341238+02:00
 imports:
 - name: cloud.google.com/go
-  version: e4de3dc4493f142c5833f3185e1182025a61f805
+  version: 01b9e8cbca61bf2c704946d6f1790ec412519180
   subpackages:
   - compute/metadata
-  - internal
 - name: github.com/akutz/gofig
   version: 862741cad5edced279c57d1981e8e3e9fa54e8d5
   subpackages:
@@ -23,42 +22,42 @@ imports:
   - vboxwebsrv
   - virtualboxclient
 - name: github.com/asaskevich/govalidator
-  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
+  version: 2c14e1cca90af49b3b21fe2d7aaa8cc7f9da2ff8
 - name: github.com/aws/aws-sdk-go
   version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   repo: https://github.com/aws/aws-sdk-go
   subpackages:
   - aws
-  - aws/awserr
-  - aws/awsutil
-  - aws/client
-  - aws/client/metadata
-  - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
+  - aws/ec2metadata
+  - aws/session
+  - service/ec2
+  - aws/awserr
+  - service/efs
+  - service/s3
+  - aws/endpoints
+  - aws/client
+  - aws/client/metadata
+  - aws/request
+  - aws/corehandlers
   - aws/credentials/stscreds
   - aws/defaults
-  - aws/ec2metadata
-  - aws/endpoints
-  - aws/request
-  - aws/session
+  - aws/awsutil
   - aws/signer/v4
   - private/protocol
   - private/protocol/ec2query
-  - private/protocol/json/jsonutil
-  - private/protocol/jsonrpc
-  - private/protocol/query
-  - private/protocol/query/queryutil
-  - private/protocol/rest
+  - private/waiter
   - private/protocol/restjson
   - private/protocol/restxml
-  - private/protocol/xml/xmlutil
-  - private/waiter
-  - service/ec2
-  - service/efs
-  - service/s3
   - service/sts
+  - aws/credentials/endpointcreds
+  - private/protocol/rest
+  - private/protocol/query/queryutil
+  - private/protocol/xml/xmlutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/json/jsonutil
 - name: github.com/Azure/azure-sdk-for-go
   version: 0984e0641ae43b89283223034574d6465be93bf4
   subpackages:
@@ -67,8 +66,8 @@ imports:
 - name: github.com/Azure/go-autorest
   version: 8a25372bbfec739b8719a9e3987400d15ef9e179
   subpackages:
-  - autorest
   - autorest/azure
+  - autorest
   - autorest/date
   - autorest/to
   - autorest/validation
@@ -82,15 +81,15 @@ imports:
   version: 2ea94fb4dd4f34507c9d67d8d2e35dcc0edb5f89
   subpackages:
   - api
-  - api/json
   - api/v1
   - api/v2
+  - api/json
 - name: github.com/codedellemc/goscaleio
   version: 485da3636bfcc8e70f74fe7bdc7cb25e5a6e4c4a
   repo: https://github.com/codedellemc/goscaleio
   subpackages:
-  - tls
   - types/v1
+  - tls
 - name: github.com/codedellemc/gournal
   version: 4293aaf7e91602963a5777caef4b346e1cf21936
   subpackages:
@@ -104,21 +103,19 @@ imports:
 - name: github.com/digitalocean/godo
   version: 84099941ba2381607e1b05ffd4822781af86675e
 - name: github.com/fsnotify/fsnotify
-  version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
+  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
   subpackages:
   - proto
 - name: github.com/google/go-querystring
   version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
-- name: github.com/googleapis/gax-go
-  version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/gophercloud/gophercloud
-  version: d5eda9707e146108e4d424062b602fd97a71c2e6
+  version: 9a5595b8ffe429439c63781cdc312c254e4ad990
   subpackages:
   - openstack
   - openstack/blockstorage/extensions/volumeactions
@@ -135,16 +132,16 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 757bef944d0f21880861c2dd9c871ca543023cba
+  version: 599cba5e7b6137d46ddf58fb1765f5d928e69604
 - name: github.com/hashicorp/hcl
-  version: f74cf8281543a0797d7b4ab7d88e76e7ba125308
+  version: 7fa7fff964d035e8a162cce3a164b3ad02ad651b
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/scanner
+  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
@@ -156,54 +153,18 @@ imports:
   version: 9d302b58e975387d0b4d9be876622c86cefe64be
   repo: https://github.com/kardianos/osext.git
   vcs: git
-- name: github.com/kr/fs
-  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: 0723e352fa358f9322c938cc2dadda874e9151a9
+  version: 51463bfca2576e06c62a8504b5c0f06d61312647
 - name: github.com/mitchellh/mapstructure
-  version: f3009df150dadf309fdee4a54ed65c124afad715
+  version: cc8532a8e9a55ea36402aa21efdf403a60d34096
 - name: github.com/onsi/ginkgo
   version: 77a8c1e5c40d6bb6c5eb4dd4bdce9763564f6298
-  subpackages:
-  - config
-  - internal/codelocation
-  - internal/containernode
-  - internal/failer
-  - internal/leafnodes
-  - internal/remote
-  - internal/spec
-  - internal/spec_iterator
-  - internal/specrunner
-  - internal/suite
-  - internal/testingtproxy
-  - internal/writer
-  - reporters
-  - reporters/stenographer
-  - reporters/stenographer/support/go-colorable
-  - reporters/stenographer/support/go-isatty
-  - types
 - name: github.com/onsi/gomega
   version: 334b8f472b3af5d541c5642701c1e29e2126f486
-  subpackages:
-  - format
-  - internal/assertion
-  - internal/asyncassertion
-  - internal/oraclematcher
-  - internal/testingtsupport
-  - matchers
-  - matchers/support/goraph/bipartitegraph
-  - matchers/support/goraph/edge
-  - matchers/support/goraph/node
-  - matchers/support/goraph/util
-  - types
 - name: github.com/pelletier/go-buffruneio
-  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
+  version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
-  version: 45932ad32dfdd20826f5671da37a5f3ce9f26a8d
-- name: github.com/pkg/errors
-  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
-- name: github.com/pkg/sftp
-  version: 4d0e916071f68db74f8a73926335f809396d6b42
+  version: fe206efb84b2bc8e8cfafe6b4c1826622be969e3
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -216,13 +177,13 @@ imports:
   - openstack/blockstorage/v1/snapshots
   - openstack/blockstorage/v1/volumes
   - openstack/compute/v2/extensions/volumeattach
-  - openstack/identity/v2/tenants
   - openstack/identity/v2/tokens
   - openstack/identity/v3/tokens
   - openstack/utils
   - pagination
   - testhelper
   - testhelper/client
+  - openstack/identity/v2/tenants
 - name: github.com/rubiojr/go-vhd
   version: 96a0db67ea8209453cfa694bdf03de202d6dd8f8
   repo: https://github.com/codenrhoden/go-vhd
@@ -238,18 +199,17 @@ imports:
   version: 5f376aa629ac60c3215cc368e674bd996093a01a
   repo: https://github.com/akutz/logrus
 - name: github.com/spf13/afero
-  version: 52e4a6cfac46163658bd4f123c49b6ee7dc75f78
+  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
   subpackages:
   - mem
-  - sftp
 - name: github.com/spf13/cast
-  version: 2580bc98dc0e62908119e4737030cc2fdfc45e4c
+  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
 - name: github.com/spf13/jwalterweatherman
-  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
 - name: github.com/spf13/pflag
   version: d16db1e50e33dff1b6cdf37596cef36742128670
 - name: github.com/spf13/viper
-  version: 651d9d916abc3c3d6a91a12549495caba5edffd2
+  version: 0967fc9aceab2ce9da34061253ac10fb99bba5b2
 - name: github.com/stretchr/testify
   version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
@@ -257,27 +217,17 @@ imports:
 - name: github.com/tent/http-link-go
   version: ac974c61c2f990f4115b119354b5e0b47550e888
 - name: golang.org/x/crypto
-  version: 453249f01cfeb54c3d549ddb75ff152ca243f9d8
+  version: 3543873453996aaab2fc6b3928a35fc5ca2b5afb
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
   - pkcs12
   - pkcs12/internal/rc2
-  - ssh
 - name: golang.org/x/net
   version: b336a971b799939dd16ae9b1df8334cb8b977c4d
   subpackages:
   - context
   - context/ctxhttp
-  - http2
-  - http2/hpack
-  - idna
-  - internal/timeseries
-  - lex/httplex
-  - trace
 - name: golang.org/x/oauth2
   version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
   subpackages:
@@ -290,7 +240,7 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 85c29909967d7f171f821e7a42e7b7af76fb9598
+  version: a9a820217f98f7c8a207ec1e45a874e1fe12c478
   repo: https://github.com/golang/text.git
   vcs: git
   subpackages:
@@ -302,37 +252,25 @@ imports:
   repo: https://github.com/google/google-api-go-client
   subpackages:
   - compute/v0.beta
-  - gensupport
   - googleapi
+  - gensupport
   - googleapi/internal/uritemplates
 - name: google.golang.org/appengine
-  version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
+  version: 170382fa85b10b94728989dfcf6cc818b335c952
   subpackages:
+  - urlfetch
   - internal
+  - internal/urlfetch
   - internal/app_identity
+  - internal/modules
   - internal/base
   - internal/datastore
   - internal/log
-  - internal/modules
   - internal/remote_api
-  - internal/urlfetch
-  - urlfetch
-- name: google.golang.org/grpc
-  version: cbcceb2942a489498cf22b2f918536e819d33f0a
-  subpackages:
-  - codes
-  - credentials
-  - grpclog
-  - internal
-  - metadata
-  - naming
-  - peer
-  - stats
-  - tap
-  - transport
 - name: gopkg.in/yaml.v2
   version: bc35f417f8a7664a73d46c9def2933417c03019f
   repo: https://github.com/akutz/yaml.git
 testImports:
 - name: gopkg.in/yaml.v1
-  version: 9f9df34309c04878acc86042b16630b0f696e1de
+  version: bc35f417f8a7664a73d46c9def2933417c03019f
+  repo: https://github.com/akutz/yaml.git

--- a/glide.lock
+++ b/glide.lock
@@ -117,6 +117,21 @@ imports:
   - query
 - name: github.com/googleapis/gax-go
   version: da06d194a00e19ce00d9011a13931c3f6f6887c7
+- name: github.com/gophercloud/gophercloud
+  version: d5eda9707e146108e4d424062b602fd97a71c2e6
+  subpackages:
+  - openstack
+  - openstack/blockstorage/extensions/volumeactions
+  - openstack/blockstorage/v1/snapshots
+  - openstack/blockstorage/v1/volumes
+  - openstack/blockstorage/v2/volumes
+  - openstack/compute/v2/extensions/volumeattach
+  - openstack/identity/v3/extensions/trusts
+  - openstack/identity/v2/tokens
+  - openstack/identity/v3/tokens
+  - openstack/utils
+  - pagination
+  - openstack/identity/v2/tenants
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux

--- a/glide.yaml
+++ b/glide.yaml
@@ -92,6 +92,10 @@ import:
     ref:     96a0db67ea8209453cfa694bdf03de202d6dd8f8
     repo:    https://github.com/codenrhoden/go-vhd
 
+### OpenStack
+  - package: github.com/gophercloud/gophercloud
+    ref:     d5eda9707e146108e4d424062b602fd97a71c2e6
+
 
 ################################################################################
 ##                             Build System Tools                             ##

--- a/glide.yaml
+++ b/glide.yaml
@@ -94,7 +94,7 @@ import:
 
 ### OpenStack
   - package: github.com/gophercloud/gophercloud
-    ref:     d5eda9707e146108e4d424062b602fd97a71c2e6
+    ref:     9a5595b8ffe429439c63781cdc312c254e4ad990
 
 
 ################################################################################

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/codedellemc/libstorage/drivers/storage/fittedcloud/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/gcepd/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/executor"
+	_ "github.com/codedellemc/libstorage/drivers/storage/openstack/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/s3fs/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/executor"

--- a/imports/executors/imports_executor_openstack.go
+++ b/imports/executors/imports_executor_openstack.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_openstack
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/openstack/executor"
+)

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/codedellemc/libstorage/drivers/storage/fittedcloud/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/gcepd/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/storage"
+	_ "github.com/codedellemc/libstorage/drivers/storage/openstack/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/s3fs/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/storage"

--- a/imports/remote/imports_remote_openstack.go
+++ b/imports/remote/imports_remote_openstack.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_openstack
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/openstack/storage"
+)


### PR DESCRIPTION
fixes #182.

Notable changes :
- use cloud-init file or the metadata server to retrieve the instance uuid instead of dmidecode (kept as a fallback). dmidecode needs root so it is better to avoid it if possible.
- remove the xen-store-read executable dependency. Region parameter is optional so let's not try to guess it.
- same for the availability zone : guessing using the metadata server was wrong anyway since AZs for compute are different from AZs for volume.
- add support of trust id for keystone auth.
